### PR TITLE
Add touch support for preset control (next/previous)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ Handles digital controller buttons such as D-Pad and stick clicks.
 
 ---
 
+## 👆 Touch Input
+
+- Left half = **previous preset**
+- Right half = **next preset**
+- If the panel is physically rotated (and the OS is not), set `touch.rotation_degrees` to `0`, `90`, `180`, or `270` to map the touch axis.
+
+---
+
 ## 🗔 Window Events
 
 Handles SDL window-related system events.

--- a/conf/projectMAR.conf
+++ b/conf/projectMAR.conf
@@ -162,3 +162,12 @@ projectM.hardCutSensitivity = 2.0
 # Controls aspect ration correction in presets. Not all presets use aspect ratio, so this setting  only has an effect
 # on presets using the aspect ration actively.
 projectM.aspectCorrectionEnabled = true
+
+# Touch screen support for preset navigation
+# Left half of screen = previous preset, Right half = next preset
+touch.enabled = true
+
+# Touch rotation in degrees clockwise to map physical panel rotation
+# Controls which region of the screen is used for previous/next preset navigation
+# Allowed values: 0, 90, 180, 270
+touch.rotation_degrees = 0

--- a/core/RenderingLoop.py
+++ b/core/RenderingLoop.py
@@ -327,7 +327,26 @@ class RenderingLoop:
                 case sdl2.SDL_MOUSEBUTTONDOWN:
                     if event.button.button == sdl2.SDL_BUTTON_RIGHT:
                         self.sdl_rendering.toggle_fullscreen()
-                        
+
+                case sdl2.SDL_FINGERDOWN:
+                    if self.config.projectm.get('touch.enabled', True):
+                        rotation = int(self.config.projectm.get('touch.rotation_degrees', 0)) % 360
+                        x, y = event.tfinger.x, event.tfinger.y
+
+                        is_left = {
+                            0: x < 0.5,
+                            90: y < 0.5,
+                            180: x >= 0.5,
+                            270: y >= 0.5,
+                        }.get(rotation, x < 0.5)
+
+                        if is_left:
+                            log.debug('Touch on left side - previous preset')
+                            self.projectm_wrapper.previous_preset()
+                        else:
+                            log.debug('Touch on right side - next preset')
+                            self.projectm_wrapper.next_preset()
+
                 case sdl2.SDL_WINDOWEVENT:
                     self.window_event(event)
 


### PR DESCRIPTION
Fantastic repo for my use case. Exactly what I was looking for, thankyou for putting this together !

I have a pair of RPI5, each with a 8.8" 480x1920 touch display. One of them runs this repo and accepts audio via VBAN from Voicemeeter on my main PC. 
None of the RPI have a kbd/mouse so I could only really control the preset (which is locked in cfg) via SSH or VNC.

Simple PR to add touch control via `SDL_FINGERDOWN`.

- Adds logic to poll `SDL_FINGERDOWN` in `poll_events`
- Adds touch section to the `README.md`
- Introduces two config opts:
  - `touch.enabled = true` - To control whether touch is enabled or not
  - `touch.rotation_degrees` - To control the regions (If you physically rotate the display)

Left region tap = previous preset
Right region tap = next preset

Wasn't sure where you'd want the config options so they're at the bottom.

https://github.com/user-attachments/assets/a80b36a2-2c96-4585-b0cb-8b2a21872022



